### PR TITLE
Update forms.py

### DIFF
--- a/resume_builder_django/resumesite/forms.py
+++ b/resume_builder_django/resumesite/forms.py
@@ -118,7 +118,7 @@ class ContactForm(forms.Form):
 
 	def __init__(self,*args,**kwargs):
 		super().__init__(*args,**kwargs)
-		self.helper=FormHelper
+		self.helper=FormHelper()
 		self.helper.form_class = ' container justify-content-center '
 		# self.helper.label_class = ''
 		# self.helper.field_class = 'col-md-6 col-xs-9'


### PR DESCRIPTION
Fix: Corrected assignment of FormHelper to create an instance

Previously, `self.helper` was assigned the `FormHelper` class itself. This prevented the form from being rendered properly as it was not an instance. Changed `self.helper = FormHelper` to `self.helper = FormHelper()` to correctly instantiate the FormHelper class and enable instance-specific properties like `form_method` and `layout`.